### PR TITLE
dvbmediasink: depend on glib-2.0-native

### DIFF
--- a/recipes-bsp/drivers/xsarius-gstreamer1.0-plugin-dvbmediasink.bb
+++ b/recipes-bsp/drivers/xsarius-gstreamer1.0-plugin-dvbmediasink.bb
@@ -5,7 +5,7 @@ LICENSE = "GPLv2"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 LIC_FILES_CHKSUM = "file://COPYING;md5=7fbc338309ac38fefcd64b04bb903e34"
 
-DEPENDS = "gstreamer1.0 gstreamer1.0-plugins-base libdca ${@bb.utils.contains("BRAND_OEM", "fulan", "fulan-dvb-modules" , "", d)}"
+DEPENDS = "glib-2.0-native gstreamer1.0 gstreamer1.0-plugins-base libdca ${@bb.utils.contains("BRAND_OEM", "fulan", "fulan-dvb-modules" , "", d)}"
 
 GSTVERSION = "1.0"
 


### PR DESCRIPTION
We need glib-mkenums in order to build dvbmediasink on pyro and that becomes available using glib-2.0-native.