### PR TITLE
Updates for Galaxy/Revo 4K

### DIFF
--- a/conf/machine/include/xsarius4k.inc
+++ b/conf/machine/include/xsarius4k.inc
@@ -51,7 +51,7 @@ IMAGE_CMD_tar_prepend = " \
 "
 
 MACHINE_FEATURES += "alsa usbhost wlan kernelwifi extrakernelwifi 3dtv switchoff osdposition hdmicec dvb-c"
-OPENPLI_FEATURES += "ci qtplugins kodi"
+OPENPLI_FEATURES += "ci"
 
 require conf/machine/include/arm/arch-armv7a.inc
 require conf/machine/include/xsarius-wifi.inc

--- a/conf/machine/include/xsarius4k.inc
+++ b/conf/machine/include/xsarius4k.inc
@@ -16,6 +16,7 @@ KERNEL_MODULE_AUTOLOAD += "xfs"
 MACHINE_EXTRA_RRECOMMENDS = " \
 	gstreamer1.0-plugin-dvbmediasink \
 	ntfs-3g \
+	v3d-libgles-bcm7252 \
 "
 
 EXTRA_IMAGEDEPENDS += "\
@@ -27,6 +28,8 @@ DVBMEDIASINK_CONFIG = "--with-pcm --with-eac3 --with-amr --with-wmv --with-h265 
 PREFERRED_VERSION_linux-xsarius = "3.14.28"
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-xsarius"
+PREFERRED_PROVIDER_virtual/egl = "v3d-libgles-bcm7252"
+PREFERRED_PROVIDER_virtual/libgles2 = "v3d-libgles-bcm7252"
 
 IMAGE_FSTYPES ?= "tar.bz2"
 
@@ -47,7 +50,8 @@ IMAGE_CMD_tar_prepend = " \
         rm -rf update; \
 "
 
-MACHINE_FEATURES += "alsa usbhost wlan kernelwifi extrakernelwifi 3dtv switchoff osdposition hdmicec"
+MACHINE_FEATURES += "alsa usbhost wlan kernelwifi extrakernelwifi 3dtv switchoff osdposition hdmicec dvb-c"
+OPENPLI_FEATURES += "ci qtplugins kodi"
 
 require conf/machine/include/arm/arch-armv7a.inc
 require conf/machine/include/xsarius-wifi.inc

--- a/recipes-bsp/drivers/xsarius-dvb-modules-bcm7252s-200mm.bb
+++ b/recipes-bsp/drivers/xsarius-dvb-modules-bcm7252s-200mm.bb
@@ -7,7 +7,7 @@ KV = "3.14.28"
 KV_EXTRA = ""
 PV = "${KV}+${SRCDATE}"
 
-SRCDATE = "20170713"
+SRCDATE = "20180110"
 
 # @description : model_size is 200mm and 300mm.
 # ex) bcmlinuxdvb_7252S-200mm-3.14.28-20161130.tar.gz.
@@ -36,5 +36,6 @@ do_install() {
 		    echo $i _hwtype=\$hwtypenum >> ${D}/${sysconfdir}/modules-load.d/_${MACHINE}.conf
 		done
 }
-SRC_URI[md5sum] = "fcf11fbefecf940dd7624db586e61d34"
-SRC_URI[sha256sum] = "c60191108050038dea483ab55faadbe4e29c9792349b9b9b1a5e2bf4fa43f08c"
+
+SRC_URI[md5sum] = "4e9e089596bf8a54c3fcbbeeeb85bb67"
+SRC_URI[sha256sum] = "5de1e9462acef3386067bfd3cccfd90e813c8aafbb96294e70b89d38a50bf3a2"

--- a/recipes-bsp/drivers/xsarius-dvb-modules-bcm7252s-300mm.bb
+++ b/recipes-bsp/drivers/xsarius-dvb-modules-bcm7252s-300mm.bb
@@ -7,7 +7,7 @@ KV = "3.14.28"
 KV_EXTRA = ""
 PV = "${KV}+${SRCDATE}"
 
-SRCDATE = "20170808"
+SRCDATE = "20180110"
 
 # @description : model_size is 200mm and 300mm.
 # ex) bcmlinuxdvb_7252S-200mm-3.14.28-20161130.tar.gz.
@@ -37,5 +37,6 @@ do_install() {
 		done
 }
 
-SRC_URI[md5sum] = "0ba84bbf7e9b2163cddf7fbaf9bb63a6"
-SRC_URI[sha256sum] = "f3c8a1034761427b47b699888e69abd5b5c4d1a940829bc002dcbf4b50dec2f8"
+
+SRC_URI[md5sum] = "8fd3ee3bfa5120b3cb00951027bce344"
+SRC_URI[sha256sum] = "fc4b0f6c5519b1db451e7c10c72f05d2b561a5f58d52e06d667a3b26d0c49b21"

--- a/recipes-bsp/v3d-drivers/v3d-libgles-bcm7252.bb
+++ b/recipes-bsp/v3d-drivers/v3d-libgles-bcm7252.bb
@@ -1,0 +1,8 @@
+require v3d-libgles-xsarius.inc
+
+SRCDATE = "20170314"
+SRCDATE_PR = "r0"
+PV="16.1"
+
+SRC_URI[md5sum] = "89db82aba385bdbb1bf52fa200d866b4"
+SRC_URI[sha256sum] = "67ce61810ceef90ff6052f639a2b0bee3f97dd150bde1526a79131be1dacee36"

--- a/recipes-bsp/v3d-drivers/v3d-libgles-xsarius.inc
+++ b/recipes-bsp/v3d-drivers/v3d-libgles-xsarius.inc
@@ -1,0 +1,45 @@
+DESCRIPTION = "GLES/EGL files for ${MACHINE}"
+SECTION = "base"
+PRIORITY = "required"
+LICENSE = "CLOSED"
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+require conf/license/license-close.inc
+
+PR="${SRCDATE}.${SRCDATE_PR}"
+
+PROVIDES = "virtual/libgles2 virtual/egl"
+
+SRC_URI = "http://en3homeftp.net/pub/src/libgles-arm-${PV}-${PR}.tar.gz"
+
+S = "${WORKDIR}/libgles"
+
+do_configure() {
+}
+
+do_compile() {
+}
+
+do_install() {
+	install -d ${D}${libdir}
+	install -m 0755 ${S}/lib/libnxpl.so ${D}${libdir}/
+	install -m 0755 ${S}/lib/libnexus.so ${D}${libdir}/
+	install -m 0755 ${S}/lib/libv3ddriver.so ${D}${libdir}/
+	ln -s libv3ddriver.so ${D}${libdir}/libEGL.so
+	ln -s libv3ddriver.so ${D}${libdir}/libGLESv2.so
+	install -d ${D}/${includedir}
+	install -m 0644 ${S}/include/v3dplatform.h ${D}${includedir}/
+	for d in CL EGL GLES GLES2 GLES3 KHR; do
+		install -d ${D}${includedir}/$d
+		for f in ${S}/include/$d/*.h; do
+			install -m 0644 $f ${D}${includedir}/$d/
+		done
+	done
+}
+
+FILES_${PN} = "/usr/lib/*"
+FILES_${PN}-dev = "/usr/include/*"
+
+RPROVIDES_${PN} = "virtual/libgles2 virtual/egl libnxpl.so libnexus.so libv3ddriver.so libGLESv2.so libEGL.so"
+
+INSANE_SKIP_${PN} += "already-stripped dev-so"
+


### PR DESCRIPTION
- Update drivers to 20180110
- Enable DVB-C and CI features
- Add non-working OpenGL ES / EGL placeholder drivers