### PR TITLE
Changes to support OE Zeus with gcc9

### DIFF
--- a/recipes-bsp/drivers/xsarius-opera-dumpait.bb
+++ b/recipes-bsp/drivers/xsarius-opera-dumpait.bb
@@ -10,7 +10,7 @@ PV = "git${SRCPV}"
 PKGV = "git${GITPKGV}"
 PR = "r11"
 
-PACKAGES += " ${PN}-src"
+#PACKAGES += " ${PN}-src"
 
 DEPENDS = "libdvbsi++"
 

--- a/recipes-bsp/linux/linux-xsarius-3.14.28/kernel-gcc9.patch
+++ b/recipes-bsp/linux/linux-xsarius-3.14.28/kernel-gcc9.patch
@@ -1,0 +1,62 @@
+--- /dev/null
++++ b/include/linux/compiler-gcc9.h
+@@ -0,0 +1,59 @@
++#ifndef __LINUX_COMPILER_H
++#error "Please don't include <linux/compiler-gcc9.h> directly, include <linux/compiler.h> instead."
++#endif
++
++#define __used				__attribute__((__used__))
++#define __must_check			__attribute__((warn_unused_result))
++#define __compiler_offsetof(a, b)	__builtin_offsetof(a, b)
++
++/* Mark functions as cold. gcc will assume any path leading to a call
++   to them will be unlikely.  This means a lot of manual unlikely()s
++   are unnecessary now for any paths leading to the usual suspects
++   like BUG(), printk(), panic() etc. [but let's keep them for now for
++   older compilers]
++
++   gcc also has a __attribute__((__hot__)) to move hot functions into
++   a special section, but I don't see any sense in this right now in
++   the kernel context */
++#define __cold			__attribute__((__cold__))
++
++#define __UNIQUE_ID(prefix) __PASTE(__PASTE(__UNIQUE_ID_, prefix), __COUNTER__)
++
++#ifndef __CHECKER__
++# define __compiletime_warning(message) __attribute__((warning(message)))
++# define __compiletime_error(message) __attribute__((error(message)))
++#endif /* __CHECKER__ */
++
++/*
++ * Mark a position in code as unreachable.  This can be used to
++ * suppress control flow warnings after asm blocks that transfer
++ * control elsewhere.
++ */
++#define unreachable() __builtin_unreachable()
++
++/* Mark a function definition as prohibited from being cloned. */
++#define __noclone	__attribute__((__noclone__))
++
++/*
++ * Tell the optimizer that something else uses this function or variable.
++ */
++#define __visible __attribute__((externally_visible))
++
++/*
++ * GCC 'asm goto' miscompiles certain code sequences:
++ *
++ *   http://gcc.gnu.org/bugzilla/show_bug.cgi?id=58670
++ *
++ * Work it around via a compiler barrier quirk suggested by Jakub Jelinek.
++ *
++ * (asm goto is automatically volatile - the naming reflects this.)
++ */
++#define asm_volatile_goto(x...)	do { asm goto(x); asm (""); } while (0)
++
++#ifdef CONFIG_ARCH_USE_BUILTIN_BSWAP
++#define __HAVE_BUILTIN_BSWAP32__
++#define __HAVE_BUILTIN_BSWAP64__
++#define __HAVE_BUILTIN_BSWAP16__
++#endif /* CONFIG_ARCH_USE_BUILTIN_BSWAP */
++
++#define KASAN_ABI_VERSION 5

--- a/recipes-bsp/linux/linux-xsarius_3.14.28.bb
+++ b/recipes-bsp/linux/linux-xsarius_3.14.28.bb
@@ -22,6 +22,7 @@ SRC_URI = "http://en3homeftp.net/pub/src/linux-${KV}.tar.xz \
         file://kernel-gcc6.patch \
         file://kernel-gcc7.patch \
 	file://kernel-gcc8.patch \
+	file://kernel-gcc9.patch \
 	file://0003-mips-kernel-ilog2-gcc7.patch \
 	file://0003-3.x-uaccess-dont-mark-register-as-const.patch \
         file://defconfig \
@@ -37,7 +38,7 @@ KERNEL_OUTPUT = "arch/${ARCH}/boot/${KERNEL_IMAGETYPE}"
 KERNEL_OBJECT_SUFFIX = "ko"
 KERNEL_IMAGEDEST = "tmp"
 
-FILES_kernel-image = "/${KERNEL_IMAGEDEST}/zImage"
+FILES_${KERNEL_PACKAGE_NAME}-image = "/${KERNEL_IMAGEDEST}/zImage"
 
 do_configure_prepend() {
 }

--- a/recipes-webkit/webkit/dumpait-legacy.bb
+++ b/recipes-webkit/webkit/dumpait-legacy.bb
@@ -11,7 +11,7 @@ PV = "git${SRCPV}"
 PKGV = "git${GITPKGV}"
 PR = "r0"
 
-PACKAGES += " ${PN}-src"
+#PACKAGES += " ${PN}-src"
 
 DEPENDS = "libdvbsi++"
 


### PR DESCRIPTION
Fix missing kernel include: fatal error: linux/compiler-gcc9.h: No such file or directory
Change FILES_kernel-image into FILES_${KERNEL_PACKAGE_NAME}-image
Fix dumpait-legacy-src listed multiple times.